### PR TITLE
Add fabric step to sofa workflow

### DIFF
--- a/src/components/canape/components/CanapeTissuStep.tsx
+++ b/src/components/canape/components/CanapeTissuStep.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+
+interface CanapeTissuStepProps {
+  selected: string | undefined;
+  onSelect: (tissu: string) => void;
+}
+
+const tissus = [
+  {
+    id: "tissu",
+    name: "Tissu classique",
+    description: "Revêtement textile standard",
+  },
+  {
+    id: "velours",
+    name: "Velours",
+    description: "Tissu doux type velours",
+  },
+  {
+    id: "cuir",
+    name: "Cuir / simili",
+    description: "Revêtement cuir ou simili",
+  },
+];
+
+const CanapeTissuStep: React.FC<CanapeTissuStepProps> = ({ selected, onSelect }) => {
+  return (
+    <div className="grid md:grid-cols-3 gap-6 font-[Outfit]">
+      {tissus.map((t) => {
+        const isSelected = selected === t.id;
+        return (
+          <div
+            key={t.id}
+            role="button"
+            tabIndex={0}
+            onClick={() => onSelect(t.id)}
+            onKeyDown={(e) => e.key === "Enter" && onSelect(t.id)}
+            aria-pressed={isSelected}
+            className={`rounded-2xl overflow-hidden border cursor-pointer transition-transform duration-300 hover:scale-[1.015] ${
+              isSelected ? "border-blue-600" : "border-gray-200 hover:border-blue-300"
+            }`}
+          >
+            <div className="p-5">
+              <h3 className="text-lg font-semibold text-gray-900 mb-1">{t.name}</h3>
+              <p className="text-sm text-gray-600 mb-4">{t.description}</p>
+              <span
+                className={`inline-block px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-300 ${
+                  isSelected ? "bg-blue-600 text-white" : "bg-gray-100 text-blue-700 hover:bg-blue-600 hover:text-white"
+                }`}
+              >
+                {isSelected ? "Sélectionné" : "Choisir"}
+              </span>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default CanapeTissuStep;

--- a/src/components/canape/components/ContactStep.tsx
+++ b/src/components/canape/components/ContactStep.tsx
@@ -5,10 +5,11 @@ import * as yup from "yup";
 import { Plus, Send, RotateCw, X } from "lucide-react";
 
 interface ContactStepProps {
+  selectedTissu: string;
   selectedFormule: string;
   selectedOptions: string[];
   onSubmit: (data: FormData) => void;
-  allDemandes?: { formule: string; options: string[] }[];
+  allDemandes?: { tissu: string; formule: string; options: string[] }[];
   onAddCanape?: () => void;
   onFullReset?: () => void;
   onDeleteCanape?: (index: number) => void;
@@ -32,6 +33,7 @@ const schema = yup.object({
 });
 
 const ContactStep: React.FC<ContactStepProps> = ({
+  selectedTissu,
   selectedFormule,
   selectedOptions,
   onSubmit,
@@ -48,7 +50,10 @@ const ContactStep: React.FC<ContactStepProps> = ({
     resolver: yupResolver(schema),
   });
 
-  const fullDemandes = [...allDemandes, { formule: selectedFormule, options: selectedOptions }];
+  const fullDemandes = [
+    ...allDemandes,
+    { tissu: selectedTissu, formule: selectedFormule, options: selectedOptions },
+  ];
 
   const formulePrices: Record<string, number> = {
     "2 places": 40,
@@ -147,6 +152,9 @@ const ContactStep: React.FC<ContactStepProps> = ({
             {demandesWithTotal.map((demande, index) => (
               <li key={index} className="py-4 relative group">
                 <p className="font-semibold text-blue-600">Canapé {index + 1}</p>
+                <p>
+                  <span className="font-medium text-gray-800">Tissu :</span> {demande.tissu}
+                </p>
                 <p>
                   <span className="font-medium text-gray-800">Formule :</span> {demande.formule}
                 </p>

--- a/src/components/canape/components/VerticalProgressBar.tsx
+++ b/src/components/canape/components/VerticalProgressBar.tsx
@@ -2,14 +2,16 @@ import React, { useEffect, useRef, useState } from "react";
 
 interface VerticalProgressBarProps {
   activeStep: number;
+  selectedTissu?: string;
   selectedFormule?: string;
   selectedOptions?: string[];
 }
 
-const steps = ["Canapé", "Options", "Contact"];
+const steps = ["Tissu", "Places", "Options", "Contact"];
 
 const VerticalProgressBar: React.FC<VerticalProgressBarProps> = ({
   activeStep,
+  selectedTissu,
   selectedFormule,
   selectedOptions,
 }) => {
@@ -27,8 +29,10 @@ const VerticalProgressBar: React.FC<VerticalProgressBarProps> = ({
   const getStepValue = (index: number) => {
     switch (index) {
       case 0:
-        return selectedFormule || "";
+        return selectedTissu || "";
       case 1:
+        return selectedFormule || "";
+      case 2:
         return selectedOptions?.length ? selectedOptions.join(", ") : "";
       default:
         return "";

--- a/src/components/canape/page/Canapes.tsx
+++ b/src/components/canape/page/Canapes.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useRef, useState } from "react";
 import FormuleStep from "../components/CanapeTypeStep";
+import TissuStep from "../components/CanapeTissuStep";
 import OptionsStep from "../components/CanapeOptionsStep";
 import ContactStep from "../components/ContactStep";
 import VerticalProgressBar from "../components/VerticalProgressBar";
 import Navbar from "../../../components/Navbar/Navbar";
 
 export default function Canapes() {
+  const [selectedTissu, setSelectedTissu] = useState<string | undefined>();
   const [selectedFormule, setSelectedFormule] = useState<string | undefined>();
   const [selectedOptions, setSelectedOptions] = useState<string[]>([]);
   const [demandes, setDemandes] = useState<any[]>([]);
@@ -21,18 +23,19 @@ export default function Canapes() {
   };
 
   const scrollToContact = () => {
-    if (!selectedFormule || selectedOptions.length === 0) {
+    if (!selectedTissu || !selectedFormule) {
       setFormError("Veuillez compléter chaque étape avant de poursuivre.");
       setShowErrorModal(true);
       return;
     }
     setFormError(null);
     setShowErrorModal(false);
-    scrollToNextSection(2);
+    scrollToNextSection(3);
   };
 
   const handleAddCanape = () => {
     const currentDemande = {
+      tissu: selectedTissu,
       formule: selectedFormule,
       options: selectedOptions,
     };
@@ -42,6 +45,7 @@ export default function Canapes() {
 
   const handleFinalSubmit = (contactData: any) => {
     const finalDemande = {
+      tissu: selectedTissu,
       formule: selectedFormule,
       options: selectedOptions,
     };
@@ -51,6 +55,7 @@ export default function Canapes() {
   };
 
   const resetFilters = () => {
+    setSelectedTissu(undefined);
     setSelectedFormule(undefined);
     setSelectedOptions([]);
     scrollToNextSection(0);
@@ -67,7 +72,7 @@ export default function Canapes() {
     resetFilters();
   };
 
-  const steps = ["Type de Canapé", "Options", "Contact"];
+  const steps = ["Type de tissu", "Places", "Options", "Contact"];
 
   // useEffect supprimé ici (il causait un freeze lors de la navigation)
 
@@ -78,6 +83,7 @@ export default function Canapes() {
       <div className="min-h-screen bg-gradient-to-b from-white to-gray-50">
         <VerticalProgressBar
           activeStep={activeSection}
+          selectedTissu={selectedTissu}
           selectedFormule={selectedFormule}
           selectedOptions={selectedOptions}
         />
@@ -121,12 +127,20 @@ export default function Canapes() {
 
         {/* Formulaires */}
         <div className="max-w-7xl mx-auto px-4 py-12 space-y-24">
-          {[<FormuleStep
-              key="type"
+          {[<TissuStep
+              key="tissu"
+              selected={selectedTissu}
+              onSelect={(t) => {
+                setSelectedTissu(t);
+                scrollToNextSection(1);
+              }}
+            />,
+            <FormuleStep
+              key="places"
               selected={selectedFormule}
               onSelect={(formule) => {
                 setSelectedFormule(formule);
-                scrollToNextSection(1);
+                scrollToNextSection(2);
               }}
             />,
             <OptionsStep
@@ -145,6 +159,7 @@ export default function Canapes() {
             />,
             <ContactStep
               key="contact"
+              selectedTissu={selectedTissu || ""}
               selectedFormule={selectedFormule || ""}
               selectedOptions={selectedOptions}
               onSubmit={handleFinalSubmit}


### PR DESCRIPTION
## Summary
- build out "canapés" flow with a new fabric selection step
- extend progress bar and contact form to handle fabric data
- update page logic for 3-step workflow before contact
- remove placeholder fabric images

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6885e68b7f4c832bbce53bc6c41f887f